### PR TITLE
fix: move app configuration data owner role assignment to parent module

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ End-to-end testing is not conducted on these modules, as they are individual com
 | Name | Type |
 |------|------|
 | [azurerm_app_configuration.conf](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_configuration) | resource |
+| [azurerm_role_assignment.role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,5 @@
+data "azurerm_client_config" "current" {}
+
 # app configurations
 resource "azurerm_app_configuration" "conf" {
   for_each = var.configs
@@ -16,4 +18,13 @@ resource "azurerm_app_configuration" "conf" {
   tags = try(
     each.value.tags, var.tags, null
   )
+}
+
+# roles
+resource "azurerm_role_assignment" "role" {
+  for_each = var.configs
+
+  scope                = azurerm_app_configuration.conf[each.key].id
+  role_definition_name = "App Configuration Data Owner"
+  principal_id         = data.azurerm_client_config.current.object_id
 }

--- a/modules/keys/README.md
+++ b/modules/keys/README.md
@@ -21,8 +21,6 @@ This submodule illustrates how to manage app configuration keys
 | Name | Type |
 |------|------|
 | [azurerm_app_configuration_key.keys](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_configuration_key) | resource |
-| [azurerm_role_assignment.role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs
 

--- a/modules/keys/main.tf
+++ b/modules/keys/main.tf
@@ -1,5 +1,3 @@
-data "azurerm_client_config" "current" {}
-
 # keys
 resource "azurerm_app_configuration_key" "keys" {
   for_each = {
@@ -15,22 +13,4 @@ resource "azurerm_app_configuration_key" "keys" {
   type                   = each.value.vault_key_reference != null ? "vault" : "kv"
   value                  = each.value.vault_key_reference == null ? each.value.value : null
   vault_key_reference    = each.value.vault_key_reference
-
-  depends_on = [azurerm_role_assignment.role]
-}
-
-# role
-resource "azurerm_role_assignment" "role" {
-  for_each = {
-    for k, v in {
-      enabled = (
-        length(lookup(var.configs, "keys", {})) > 0 ||
-        length(lookup(var.configs, "features", {})) > 0
-      ) ? true : false
-    } : k => v if v == true
-  }
-
-  scope                = var.configuration_store_id
-  role_definition_name = "App Configuration Data Owner"
-  principal_id         = data.azurerm_client_config.current.object_id
 }


### PR DESCRIPTION
## Description

This PR moves the app configuration data owner role assignment to parent module

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)